### PR TITLE
Fix memory leak in tgvoip::EchoCanceller

### DIFF
--- a/EchoCanceller.cpp
+++ b/EchoCanceller.cpp
@@ -96,6 +96,7 @@ EchoCanceller::~EchoCanceller(){
 #ifndef TGVOIP_NO_DSP
 	delete apm;
 	delete audioFrame;
+	delete farendBufferPool;
 #endif
 }
 

--- a/NetworkSocket.cpp
+++ b/NetworkSocket.cpp
@@ -364,8 +364,8 @@ bool NetworkSocketTCPObfuscated::IsFailed(){
 NetworkSocketSOCKS5Proxy::NetworkSocketSOCKS5Proxy(NetworkSocket *tcp, NetworkSocket *udp, std::string username, std::string password) : NetworkSocketWrapper(udp ? PROTO_UDP : PROTO_TCP){
 	this->tcp=tcp;
 	this->udp=udp;
-	this->username=username;
-	this->password=password;
+	this->username=std::move(username);
+	this->password=std::move(password);
 	connectedAddress=NULL;
 }
 

--- a/audio/Resampler.cpp
+++ b/audio/Resampler.cpp
@@ -58,7 +58,7 @@ static const int16_t hann[960]={
 		0x7FDE, 0x7FE1, 0x7FE4, 0x7FE7, 0x7FEA, 0x7FED, 0x7FEF, 0x7FF1, 0x7FF3, 0x7FF5, 0x7FF7, 0x7FF9, 0x7FFA, 0x7FFB, 0x7FFC, 0x7FFD, 0x7FFE, 0x7FFE, 0x7FFF, 0x7FFF
 };
 
-#define MIN(a, b) (a<b ? a : b)
+#define MIN(a, b) (((a)<(b)) ? (a) : (b))
 
 size_t Resampler::Convert48To44(int16_t *from, int16_t *to, size_t fromLen, size_t toLen){
 	size_t outLen=fromLen*147/160;

--- a/os/linux/AudioPulse.cpp
+++ b/os/linux/AudioPulse.cpp
@@ -193,7 +193,7 @@ AudioPulse::AudioPulse(std::string inputDevice, std::string outputDevice){
 	isLocked=false;
 
 	output=new AudioOutputPulse(context, mainloop, outputDevice);
-	input=new AudioInputPulse(context, mainloop, outputDevice);
+	input=new AudioInputPulse(context, mainloop, inputDevice);
 }
 
 AudioPulse::~AudioPulse(){


### PR DESCRIPTION
* Fix memory leak: deletion of farendBufferPool is needed in tgvoip::EchoCanceller destructor
* Fix unspecified behavior in VoIPController.cpp in situations like this: `function(object.get_field(), std::move(object));` According to C++ standard, the order of evaluation of function arguments is unspecified, and std::move(object) might be evaluated earlier than object.get_field().
* Fix invalid copy-paste at the end of tgvoip::audio::AudioPulse constructor
* Use std::move when passing std::string to constructor