### PR TITLE
fix calling via socks proxy on windows

### DIFF
--- a/os/windows/NetworkSocketWinsock.cpp
+++ b/os/windows/NetworkSocketWinsock.cpp
@@ -694,7 +694,7 @@ bool NetworkSocketWinsock::Select(std::vector<NetworkSocket*> &readFds, std::vec
 	}
 	//LOGV("select fds left: read=%d, error=%d", readFds.size(), errorFds.size());
 
-	return readFds.size()>0 || errorFds.size()>0;
+	return readFds.size()>0 || errorFds.size()>0 || writeFds.size()>0;
 }
 
 SocketSelectCancellerWin32::SocketSelectCancellerWin32(){


### PR DESCRIPTION
This bug caused initial proxy checking for UDP ASSOCIATE support to be cancelled, as ability to write initial socks5 handshake to opened socket was ignored. Then call's udp traffic was routed directly, not via proxy.