### PR TITLE
Fix build of bundled WebRTC on GNU/Hurd or FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -386,7 +386,7 @@ SRC += \
 webrtc_dsp/rtc_base/logging_mac.mm \
 webrtc_dsp/rtc_base/logging_mac.h
 else
-CFLAGS += -DWEBRTC_LINUX
+CFLAGS += $(if $(filter linux%,@host_os@),-DWEBRTC_LINUX)
 endif
 
 if TARGET_CPU_X86

--- a/webrtc_dsp/rtc_base/platform_thread_types.cc
+++ b/webrtc_dsp/rtc_base/platform_thread_types.cc
@@ -31,7 +31,7 @@ PlatformThreadId CurrentThreadId() {
   return syscall(__NR_gettid);
 #else
   // Default implementation for nacl and solaris.
-  return reinterpret_cast<pid_t>(pthread_self());
+  return static_cast<pid_t>(pthread_self());
 #endif
 #endif  // defined(WEBRTC_POSIX)
 }


### PR DESCRIPTION
1. Add a check for Linux before define the WEBRTC_LINUX macro.
2. Static cast for convert thread ID by compiler itself.
