### PR TITLE
audio: Build on OpenBSD

### DIFF
--- a/VoIPController.cpp
+++ b/VoIPController.cpp
@@ -3014,7 +3014,7 @@ static void initMachTimestart() {
 #endif
 
 double VoIPController::GetCurrentTime(){
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return ts.tv_sec+(double)ts.tv_nsec/1000000000.0;

--- a/audio/AudioIO.cpp
+++ b/audio/AudioIO.cpp
@@ -31,7 +31,7 @@
 #endif
 #include "../os/windows/AudioInputWASAPI.h"
 #include "../os/windows/AudioOutputWASAPI.h"
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__gnu_hurd__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__gnu_hurd__)
 #ifndef WITHOUT_ALSA
 #include "../os/linux/AudioInputALSA.h"
 #include "../os/linux/AudioOutputALSA.h"
@@ -65,7 +65,7 @@ AudioIO* AudioIO::Create(std::string inputDevice, std::string outputDevice){
 		return new ContextlessAudioIO<AudioInputWave, AudioOutputWave>(inputDevice, outputDevice);
 #endif
 	return new ContextlessAudioIO<AudioInputWASAPI, AudioOutputWASAPI>(inputDevice, outputDevice);
-#elif defined(__linux__) || defined(__FreeBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #ifndef WITHOUT_ALSA
 #ifndef WITHOUT_PULSE
 	if(AudioPulse::Load()){

--- a/audio/AudioInput.cpp
+++ b/audio/AudioInput.cpp
@@ -26,7 +26,7 @@
 #include "../os/windows/AudioInputWave.h"
 #endif
 #include "../os/windows/AudioInputWASAPI.h"
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__gnu_hurd__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__gnu_hurd__)
 #ifndef WITHOUT_ALSA
 #include "../os/linux/AudioInputALSA.h"
 #endif
@@ -72,7 +72,7 @@ void AudioInput::EnumerateDevices(std::vector<AudioInputDevice>& devs){
 	}
 #endif
 	AudioInputWASAPI::EnumerateDevices(devs);
-#elif (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__)
+#elif (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #if !defined(WITHOUT_PULSE) && !defined(WITHOUT_ALSA)
 	if(!AudioInputPulse::EnumerateDevices(devs))
 		AudioInputALSA::EnumerateDevices(devs);

--- a/audio/AudioOutput.cpp
+++ b/audio/AudioOutput.cpp
@@ -29,7 +29,7 @@
 #include "../os/windows/AudioOutputWave.h"
 #endif
 #include "../os/windows/AudioOutputWASAPI.h"
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__gnu_hurd__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__gnu_hurd__)
 #ifndef WITHOUT_ALSA
 #include "../os/linux/AudioOutputALSA.h"
 #endif
@@ -83,7 +83,7 @@ void AudioOutput::EnumerateDevices(std::vector<AudioOutputDevice>& devs){
 	}
 #endif
 	AudioOutputWASAPI::EnumerateDevices(devs);
-#elif (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__)
+#elif (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #if !defined(WITHOUT_PULSE) && !defined(WITHOUT_ALSA)
 	if(!AudioOutputPulse::EnumerateDevices(devs))
 		AudioOutputALSA::EnumerateDevices(devs);


### PR DESCRIPTION
OpenBSD supports PulseAudio and OpenAL, but not ALSA.
Either PulseAudio or ALSA are required for libtgvoip.

Add missing OS macros to enable building with
`LIBTGVOIP_DISABLE_PULSEAUDIO=ON` `LIBTGVOIP_DISABLE_ALSA=OFF` as tested
on OpenBSD/amd64 7.2-current.