### PR TITLE
Fix missing cstdint for GCC 15

### DIFF
--- a/TgVoip.h
+++ b/TgVoip.h
@@ -1,6 +1,7 @@
 #ifndef __TGVOIP_H
 #define __TGVOIP_H
 
+#include <cstdint>
 #include <functional>
 #include <vector>
 #include <string>

--- a/json11.cpp
+++ b/json11.cpp
@@ -22,6 +22,7 @@
 #include "json11.hpp"
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <limits>


### PR DESCRIPTION
Ref: https://bugs.gentoo.org/938332